### PR TITLE
fix: IsSameDay returns true when on first day of first month in a year when t1 is zero

### DIFF
--- a/filerotate/filerotate.go
+++ b/filerotate/filerotate.go
@@ -32,7 +32,7 @@ type File struct {
 }
 
 func IsSameDay(t1, t2 time.Time) bool {
-	return t1.YearDay() == t2.YearDay()
+	return t1.YearDay() == t2.YearDay() && t1.Year() == t2.Year()
 }
 
 func IsSameHour(t1, t2 time.Time) bool {


### PR DESCRIPTION
The issue is that t1 on start is not initialized, go will replace it as a zero value which will be the first of Jan. When t2 is really the first of Jan as well it returns true when it shouldn't because it is assumed that on start it should be false to either create a new file or reopen the file.

What was happening is that IsSameDay would return true and would not create the log file on start because it was thinking it was already open.

I changed IsSameDay to also check for the year, golang's default time.Time year is 1970 I believe which fixes this issue